### PR TITLE
Add DIRECT preprint to publications

### DIFF
--- a/content/bibliography/ASL_Bib.bib
+++ b/content/bibliography/ASL_Bib.bib
@@ -733,6 +733,17 @@
 
 @String{pub_WSP                        = {{World Scientific Publishing}}}
 
+@article{DaoGanaiEtAl2026,
+  author    = {Dao, J. and Ganai, M. and Abukhadra, Y. and Sridhar, A. and Nasr Azadani, M. and Luo, K. and Barrett, C. and Wu, J. and Finn, C. and Pavone, M.},
+  title     = {DIRECT: When and Where Should You Allocate Test-Time Compute in Embodied Planners?},
+  year      = {2026},
+  abstract  = {VLMs are increasingly used as high-level planners for embodied agents, and a common strategy is to scale test-time compute for better capability. But that compute buys uneven, often diminishing gains while adding latency, tokens, and FLOPs. We argue that choosing when and where to spend it is what brings frontier performance to the real world. DIRECT is a routing framework that uses multimodal scene context to allocate compute per task, improving the success-cost frontier over any fixed model.},
+  url       = {https://jadee-dao.github.io/direct/},
+  keywords  = {sub},
+  owner     = {jdao},
+  timestamp = {2026-07-01}
+}
+
 @inproceedings{ZhuSchmerlingEtAl2015,
   author    = {Zhu, Z. and Schmerling, E. and Pavone, M.},
   title     = {A Convex Optimization Approach to Smooth Trajectories for Motion Planning with Car-Like Robots},


### PR DESCRIPTION
Add Jadelynn Dao et al. "DIRECT: When and Where Should You Allocate Test-Time Compute in Embodied Planners?" as a submitted preprint.